### PR TITLE
Feat: Umstellung auf rechteckiges Hex-Grid

### DIFF
--- a/Hexus/Game1.cs
+++ b/Hexus/Game1.cs
@@ -23,8 +23,8 @@ public class Game1 : Game
     private MouseState _previousMouseState;
     private float _aiTurnTimer;
 
-    private const int GridWidth = 12;
-    private const int GridHeight = 12;
+    private const int GridWidth = 11;
+    private const int GridHeight = 10;
     private const float HexSize = 40f;
 
     public Game1()

--- a/Hexus/Managers/GridManager.cs
+++ b/Hexus/Managers/GridManager.cs
@@ -29,11 +29,13 @@ namespace Hexus.Managers
             Tiles.Clear();
             ControlPoints.Clear();
 
-            for (int r = 0; r < GridHeight; r++)
+            // Create a rectangular grid using offset coordinates, which are then converted to axial (Hex)
+            for (int row = 0; row < GridHeight; row++)
             {
-                for (int q = 0; q < GridWidth - (r / 2); q++)
+                var offset = row / 2; // This creates the offset for every second row
+                for (int col = 0; col < GridWidth; col++)
                 {
-                    AllHexes.Add(new Hex(q, r));
+                    AllHexes.Add(new Hex(col - offset, row));
                 }
             }
 


### PR DESCRIPTION
- Ändert die Grid-Erstellungslogik in `GridManager`, um ein rechteckiges, versetztes Raster anstelle eines Parallelogramms zu erzeugen.
- Aktualisiert die `GridWidth`- und `GridHeight`-Konstanten in `Game1`, um die neuen Dimensionen (11x10) widerzuspiegeln.
- Die Zentrierungslogik verwendet nun die korrekten neuen Dimensionen.